### PR TITLE
Add socket tree and schemas caching

### DIFF
--- a/lib/channel_spec/cache.ex
+++ b/lib/channel_spec/cache.ex
@@ -1,0 +1,37 @@
+defmodule ChannelSpec.Cache do
+  @moduledoc """
+  Cache for ChannelSpec specs.
+
+  Settings:
+
+  ```elixir
+  config :channel_spec, :cache_adapter, Module
+  ```
+
+  ChannelSpec ships with two cache adapters:
+
+  * `ChannelSpec.Cache.PersistentTermCache` - default
+  * `ChannelSpec.Cache.NoneCache` - none cache
+
+  If you are constantly modifying specs during development, you can configure the cache adapter
+  in `dev.exs` as follows to disable caching:
+
+  ```elixir
+  config :channel_spec, :cache_adapter, ChannelSpec.Cache.NoneCache
+  ```
+  """
+
+  @callback get(module) :: nil | map()
+  @callback put(module, map()) :: :ok
+  @callback erase(module) :: :ok
+
+  @default_adapter ChannelSpec.Cache.PersistentTermCache
+
+  @doc """
+  Get cache adapter
+  """
+  @spec adapter() :: module()
+  def adapter() do
+    Application.get_env(:channel_spec, :cache_adapter, @default_adapter)
+  end
+end

--- a/lib/channel_spec/cache/none_cache.ex
+++ b/lib/channel_spec/cache/none_cache.ex
@@ -1,0 +1,23 @@
+defmodule ChannelSpec.Cache.NoneCache do
+  @moduledoc """
+  A cache adapter to disable caching. Intended to be used in development.
+
+  Configure it with:
+
+  ```elixir
+  # config/runtime.exs
+  config :channel_handler, :cache_adapter, ChannelSpec.Cache.NoneCache
+  ```
+  """
+
+  @behaviour ChannelSpec.Cache
+
+  @impl true
+  def get(_spec_module), do: nil
+
+  @impl true
+  def put(_spec_module, _spec), do: :ok
+
+  @impl true
+  def erase(_spec_module), do: :ok
+end

--- a/lib/channel_spec/cache/persistent_term_cache.ex
+++ b/lib/channel_spec/cache/persistent_term_cache.ex
@@ -1,0 +1,24 @@
+defmodule ChannelSpec.Cache.PersistentTermCache do
+  @moduledoc """
+  A cache adapter that stores the specs in memory.
+
+  This is the default cache adapter.
+  """
+
+  @behaviour ChannelSpec.Cache
+
+  @impl true
+  def get(spec_module) do
+    :persistent_term.get(spec_module, nil)
+  end
+
+  @impl true
+  def put(spec_module, specs) do
+    :persistent_term.put(spec_module, specs)
+  end
+
+  @impl true
+  def erase(spec_module) do
+    :persistent_term.erase(spec_module)
+  end
+end

--- a/lib/channel_spec/operations.ex
+++ b/lib/channel_spec/operations.ex
@@ -86,16 +86,28 @@ defmodule ChannelSpec.Operations do
         _other, lines ->
           lines
       end)
+      |> Macro.escape()
 
-    quote location: :keep do
-      @operations {unquote(name),
-                   %{
-                     schema: unquote(params),
-                     file: unquote(file),
-                     line: unquote(line),
-                     module: unquote(module),
-                     line_metadata: unquote(Macro.escape(line_metadata))
-                   }}
+    quote location: :keep,
+          bind_quoted: [
+            name: name,
+            schema: params,
+            file: file,
+            line: line,
+            module: module,
+            line_metadata: line_metadata
+          ] do
+      operation = %{
+        schema: schema,
+        file: file,
+        line: line,
+        module: module,
+        line_metadata: line_metadata
+      }
+
+      @operations {name, operation}
+
+      def __channel_spec_operation__(unquote(name)), do: unquote(Macro.escape(operation))
     end
   end
 
@@ -106,7 +118,7 @@ defmodule ChannelSpec.Operations do
   @doc """
   Defines a subscription for the channel.
 
-  Subscriptions are messages that are sent from the server to the client, withuot
+  Subscriptions are messages that are sent from the server to the client, without
   the client requesting them. They are defined with a name and a schema that
   describes the payload.
 
@@ -128,17 +140,28 @@ defmodule ChannelSpec.Operations do
     file = __CALLER__.file
     line = __CALLER__.line
     module = __CALLER__.module
-    line_metadata = %{"event" => %{line: line}}
+    line_metadata = Macro.escape(%{"event" => %{line: line}})
 
-    quote do
-      @subscriptions {unquote(event),
-                      %{
-                        schema: unquote(schema),
-                        file: unquote(file),
-                        line: unquote(line),
-                        module: unquote(module),
-                        line_metadata: unquote(Macro.escape(line_metadata))
-                      }}
+    quote location: :keep,
+          bind_quoted: [
+            event: event,
+            file: file,
+            line: line,
+            module: module,
+            schema: schema,
+            line_metadata: line_metadata
+          ] do
+      subscription = %{
+        schema: schema,
+        file: file,
+        line: line,
+        module: module,
+        line_metadata: line_metadata
+      }
+
+      @subscriptions {event, subscription}
+
+      def __channel_spec_subscription__(unquote(event)), do: unquote(Macro.escape(subscription))
     end
   end
 

--- a/lib/mix/channel_spec_routes.ex
+++ b/lib/mix/channel_spec_routes.ex
@@ -16,6 +16,7 @@ defmodule Mix.Tasks.ChannelSpec.Routes do
 
     for {path, socket_module, _} <- endpoint_module.__sockets__() do
       try do
+        ChannelSpec.Cache.adapter().erase({socket_module, :socket_tree})
         socket_tree = socket_module.__socket_tree__()
         IO.puts(IO.ANSI.faint() <> "#{path}" <> IO.ANSI.reset())
         print_socket_routes(socket_module, socket_tree, opts)

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule ChannelSpec.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:channel_handler, "~> 0.1"},
+      {:channel_handler, "~> 0.6"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:mneme, "~> 0.5", only: [:dev, :test]},
       {:json_xema, "~> 0.6"},

--- a/mix.exs
+++ b/mix.exs
@@ -9,17 +9,9 @@ defmodule ChannelSpec.MixProject do
       app: :channel_spec,
       version: @version,
       elixir: "~> 1.13",
-      start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: docs(),
       package: package()
-    ]
-  end
-
-  # Run "mix help compile.app" to learn about applications.
-  def application do
-    [
-      extra_applications: [:logger]
     ]
   end
 

--- a/test/channel_spec/cache/none_cache_test.exs
+++ b/test/channel_spec/cache/none_cache_test.exs
@@ -1,0 +1,23 @@
+defmodule ChannelSpec.Cache.NoneCacheTest do
+  use ExUnit.Case, async: true
+
+  alias ChannelSpec.Cache.NoneCache
+
+  describe "get/1" do
+    test "returns nil" do
+      assert is_nil(NoneCache.get(SomeModule))
+    end
+  end
+
+  describe "put/2" do
+    test "returns :ok" do
+      assert :ok = NoneCache.put(SomeModule, %{})
+    end
+  end
+
+  describe "erase/1" do
+    test "returns :ok" do
+      assert :ok = NoneCache.erase(SomeModule)
+    end
+  end
+end


### PR DESCRIPTION
Closes #2

Adds a socket tree and shcemas cache module `ChannelSpec.Cache` with `PersistentTermCache` and `NoneCache` implementations.

This improves performance of code that needs to access the socket tree and the tree schemas several times(ie a socket Plug), while also providing a way to rebuild the schemas during development

The approximate performance improvements are:
- 798.25%increase in Iterations per second
- 99.35% decrease in memory usage(though I suspect this to be a bit questionable, 32B sounds like it might not have been measured correctly?)

## Benchmarks
### Without cache
```
Name                  ips        average  deviation         median         99th %
get schemas      787.08 K        1.27 μs  ±1931.28%        1.04 μs        2.17 μs

Memory usage statistics:

Name           Memory usage
get schemas         4.94 KB

Reduction count statistics:

Name        Reduction count
get schemas             343
```

### With PersistentTermCache
```
Name                  ips        average  deviation         median         99th %
get schemas        7.07 M      141.40 ns ±20706.66%         125 ns         208 ns

Memory usage statistics:

Name           Memory usage
get schemas            32 B

Reduction count statistics:

Name        Reduction count
get schemas              19
```

### With NoneCache
```
Name                  ips        average  deviation         median         99th %
get schemas      649.44 K        1.54 μs  ±1612.13%        1.21 μs        2.38 μs

Memory usage statistics:

Name           Memory usage
get schemas         5.02 KB

Reduction count statistics:

Name        Reduction count
get schemas             369
```

<details>
<summary><h3>Benchmark code</h3></summary>

```elixir
defmodule BenchmarkTests do
  defmodule Socket do
    use ChannelSpec.Socket

    channel "foo:*", BenchmarkTests.Channel
  end

  defmodule Channel do
    use Phoenix.Channel
    use ChannelHandler.Router
    use ChannelSpec.Operations

    operation "baraaaaaaaa",
      payload: %{type: :object},
      replies: %{
        ok: %{type: :string},
        error: %{stype: :string}
      }

    handle "bar", fn _payload, _context, socket ->
      {:noreply, socket}
    end
  end

  def get_schemas do
    tree = Socket.__socket_tree__()
    
    unless tree.channels["foo:{string}"].messages["bar"].function == :handle_in do
      raise "invalid result"
    end
  end
end

Benchee.run(
  %{
    "get schemas" => &BenchmarkTests.get_schemas/0,
  },
  time: 10,
  memory_time: 4,
  reduction_time: 1
)
```

</details>


## Test plan
Run the tests and verify they still work