### PR TITLE
Fix(serializer): Account for Required and Enum Properties

### DIFF
--- a/lib/channel_spec/serializer.ex
+++ b/lib/channel_spec/serializer.ex
@@ -8,6 +8,12 @@ defmodule Serializer do
         messages = Map.new(messages, fn {event, operation} -> {event, operation.schema} end)
         {:messages, messages}
 
+      {:required, required} when is_list(required) ->
+        {:required, required}
+
+      {:enum, enum} when is_list(enum) ->
+        {:enum, enum}
+
       {key, %Xema.Schema{} = schema} ->
         {key, Xema.Schema.to_map(schema)}
 

--- a/test/channel_spec/serializer_test.exs
+++ b/test/channel_spec/serializer_test.exs
@@ -20,41 +20,23 @@ defmodule ChannelSpec.SerializerTest do
         }
       }
 
-      string_schema =
+      converted_schema =
         schema
         |> Serializer.to_schema()
         |> Serializer.to_string()
+        |> Jason.decode!()
 
-      assert """
-             {
-               "properties": {
-                 "enum": {
-                   "enum": [
-                     "foo",
-                     "bar"
-                   ],
-                   "type": "string"
+      assert converted_schema == %{
+               "properties" => %{
+                 "enum" => %{"enum" => ["foo", "bar"], "type" => "string"},
+                 "one_of_array" => %{
+                   "items" => %{"one_of" => [%{"type" => "string"}, %{"type" => "number"}]},
+                   "type" => "array"
                  },
-                 "one_of_array": {
-                   "items": {
-                     "one_of": [
-                       {
-                         "type": "string"
-                       },
-                       {
-                         "type": "number"
-                       }
-                     ]
-                   },
-                   "type": "array"
-                 },
-                 "string": {
-                   "type": "string"
-                 }
+                 "string" => %{"type" => "string"}
                },
-               "type": "object"
-             }\
-             """ == string_schema
+               "type" => "object"
+             }
     end
   end
 end

--- a/test/channel_spec/serializer_test.exs
+++ b/test/channel_spec/serializer_test.exs
@@ -20,40 +20,41 @@ defmodule ChannelSpec.SerializerTest do
         }
       }
 
-      string_schema = schema
-      |> Serializer.to_schema()
-      |> Serializer.to_string()
+      string_schema =
+        schema
+        |> Serializer.to_schema()
+        |> Serializer.to_string()
 
       assert """
-      {
-        "properties": {
-          "enum": {
-            "enum": [
-              "foo",
-              "bar"
-            ],
-            "type": "string"
-          },
-          "one_of_array": {
-            "items": {
-              "one_of": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                }
-              ]
-            },
-            "type": "array"
-          },
-          "string": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      }\
-      """  == string_schema
+             {
+               "properties": {
+                 "enum": {
+                   "enum": [
+                     "foo",
+                     "bar"
+                   ],
+                   "type": "string"
+                 },
+                 "one_of_array": {
+                   "items": {
+                     "one_of": [
+                       {
+                         "type": "string"
+                       },
+                       {
+                         "type": "number"
+                       }
+                     ]
+                   },
+                   "type": "array"
+                 },
+                 "string": {
+                   "type": "string"
+                 }
+               },
+               "type": "object"
+             }\
+             """ == string_schema
     end
   end
 end

--- a/test/channel_spec/serializer_test.exs
+++ b/test/channel_spec/serializer_test.exs
@@ -1,0 +1,59 @@
+defmodule ChannelSpec.SerializerTest do
+  use ExUnit.Case, async: true
+
+  describe "to_schema/1" do
+    test "converts an elixir schema to a json schema map" do
+      schema = %{
+        type: :object,
+        properties: %{
+          string: %{type: :string},
+          enum: %{type: :string, enum: [:foo, :bar]},
+          one_of_array: %{
+            type: :array,
+            items: %{
+              one_of: [
+                %{type: :string},
+                %{type: :number}
+              ]
+            }
+          }
+        }
+      }
+
+      string_schema = schema
+      |> Serializer.to_schema()
+      |> Serializer.to_string()
+
+      assert """
+      {
+        "properties": {
+          "enum": {
+            "enum": [
+              "foo",
+              "bar"
+            ],
+            "type": "string"
+          },
+          "one_of_array": {
+            "items": {
+              "one_of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "string": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }\
+      """  == string_schema
+    end
+  end
+end


### PR DESCRIPTION
### Why am I opening this PR?
I introduced the `schema_path: "shared/channel_schema.json"` option to our `UserSocket` and was failing to generate the schema. These changes fixed the issue and generates valid JSON schema