### PR TITLE
Feat: Order Output Json

### DIFF
--- a/lib/channel_spec/serializer.ex
+++ b/lib/channel_spec/serializer.ex
@@ -62,9 +62,9 @@ defmodule Serializer do
     %{reverse_ordered | values: Enum.reverse(reverse_ordered.values)}
   end
 
-  def to_ordered_structs(list) when is_list(list) do
+  defp to_ordered_structs(list) when is_list(list) do
     Enum.map(list, &to_ordered_structs/1)
   end
 
-  def to_ordered_structs(stuff), do: stuff
+  defp to_ordered_structs(stuff), do: stuff
 end

--- a/lib/channel_spec/serializer.ex
+++ b/lib/channel_spec/serializer.ex
@@ -37,6 +37,34 @@ defmodule Serializer do
   def to_string(socket_tree) do
     socket_tree
     |> to_schema()
+    |> to_ordered_structs()
     |> Jason.encode!(pretty: true)
   end
+
+  # Helper function to ensure the order of the output json
+  @spec to_ordered_structs(map()) :: Jason.OrderedObject.t()
+  defp to_ordered_structs(map) when is_map(map) do
+    reverse_ordered =
+      map
+      |> Enum.to_list()
+      |> Enum.sort_by(fn {key, _val} -> key end, :asc)
+      |> Enum.reduce(%Jason.OrderedObject{}, fn
+        {key, value}, acc when is_map(value) ->
+          %{acc | values: [{key, to_ordered_structs(value)} | acc.values]}
+
+        {key, value}, acc when is_list(value) ->
+          %{acc | values: [{key, to_ordered_structs(value)} | acc.values]}
+
+        {key, value}, acc ->
+          %{acc | values: [{key, value} | acc.values]}
+      end)
+
+    %{reverse_ordered | values: Enum.reverse(reverse_ordered.values)}
+  end
+
+  def to_ordered_structs(list) when is_list(list) do
+    Enum.map(list, &to_ordered_structs/1)
+  end
+
+  def to_ordered_structs(stuff), do: stuff
 end

--- a/test/channel_spec/serializer_test.exs
+++ b/test/channel_spec/serializer_test.exs
@@ -38,5 +38,226 @@ defmodule ChannelSpec.SerializerTest do
                "type" => "object"
              }
     end
+
+    test "foo" do
+      schema = %{
+        type: :object,
+        properties: %{
+          b: %{type: :string},
+          c: %{type: :string},
+          x: %{type: :string},
+          d: %{type: :string},
+          electric_eel: %{type: :string},
+          e: %{type: :string},
+          h: %{type: :string},
+          f: %{type: :string},
+          g: %{type: :string},
+          dog: %{type: :string},
+          j: %{type: :string},
+          k: %{type: :string},
+          o: %{type: :string},
+          jaguar: %{type: :string},
+          l: %{type: :string},
+          lemur: %{type: :string},
+          u: %{type: :string},
+          cuttle_fish: %{type: :string},
+          m: %{type: :string},
+          n: %{type: :string},
+          ibex: %{type: :string},
+          i: %{type: :string},
+          hippopotamus: %{type: :string},
+          y: %{type: :string},
+          fox: %{type: :string},
+          q: %{type: :string},
+          a: %{type: :string},
+          z: %{type: :string},
+          koala: %{type: :string},
+          r: %{type: :string},
+          garden_snake: %{type: :string},
+          s: %{type: :string},
+          p: %{type: :string},
+          bananas: %{type: :string},
+          v: %{type: :string},
+          t: %{type: :string},
+          w: %{type: :string},
+          apples: %{type: :string},
+          one_of_list: [
+            %{
+              type: :object,
+              properties: %{
+                c: %{type: :string},
+                b: %{type: :string},
+                a: %{type: :string}
+              }
+            },
+            %{
+              type: :object,
+              properties: %{
+                f: %{type: :string},
+                e: %{type: :string},
+                d: %{type: :string}
+              }
+            }
+          ]
+        }
+      }
+
+      result =
+        schema
+        |> Serializer.to_schema()
+        |> Serializer.to_string()
+
+      assert """
+             {
+               "properties": {
+                 "a": {
+                   "type": "string"
+                 },
+                 "apples": {
+                   "type": "string"
+                 },
+                 "b": {
+                   "type": "string"
+                 },
+                 "bananas": {
+                   "type": "string"
+                 },
+                 "c": {
+                   "type": "string"
+                 },
+                 "cuttle_fish": {
+                   "type": "string"
+                 },
+                 "d": {
+                   "type": "string"
+                 },
+                 "dog": {
+                   "type": "string"
+                 },
+                 "e": {
+                   "type": "string"
+                 },
+                 "electric_eel": {
+                   "type": "string"
+                 },
+                 "f": {
+                   "type": "string"
+                 },
+                 "fox": {
+                   "type": "string"
+                 },
+                 "g": {
+                   "type": "string"
+                 },
+                 "garden_snake": {
+                   "type": "string"
+                 },
+                 "h": {
+                   "type": "string"
+                 },
+                 "hippopotamus": {
+                   "type": "string"
+                 },
+                 "i": {
+                   "type": "string"
+                 },
+                 "ibex": {
+                   "type": "string"
+                 },
+                 "j": {
+                   "type": "string"
+                 },
+                 "jaguar": {
+                   "type": "string"
+                 },
+                 "k": {
+                   "type": "string"
+                 },
+                 "koala": {
+                   "type": "string"
+                 },
+                 "l": {
+                   "type": "string"
+                 },
+                 "lemur": {
+                   "type": "string"
+                 },
+                 "m": {
+                   "type": "string"
+                 },
+                 "n": {
+                   "type": "string"
+                 },
+                 "o": {
+                   "type": "string"
+                 },
+                 "one_of_list": [
+                   {
+                     "properties": {
+                       "a": {
+                         "type": "string"
+                       },
+                       "b": {
+                         "type": "string"
+                       },
+                       "c": {
+                         "type": "string"
+                       }
+                     },
+                     "type": "object"
+                   },
+                   {
+                     "properties": {
+                       "d": {
+                         "type": "string"
+                       },
+                       "e": {
+                         "type": "string"
+                       },
+                       "f": {
+                         "type": "string"
+                       }
+                     },
+                     "type": "object"
+                   }
+                 ],
+                 "p": {
+                   "type": "string"
+                 },
+                 "q": {
+                   "type": "string"
+                 },
+                 "r": {
+                   "type": "string"
+                 },
+                 "s": {
+                   "type": "string"
+                 },
+                 "t": {
+                   "type": "string"
+                 },
+                 "u": {
+                   "type": "string"
+                 },
+                 "v": {
+                   "type": "string"
+                 },
+                 "w": {
+                   "type": "string"
+                 },
+                 "x": {
+                   "type": "string"
+                 },
+                 "y": {
+                   "type": "string"
+                 },
+                 "z": {
+                   "type": "string"
+                 }
+               },
+               "type": "object"
+             }\
+             """ == result
+    end
   end
 end


### PR DESCRIPTION
### Why am I opening this PR?
This PR aims to produce a predictable JSON output to prevent churn on the schema files that are generated when using `use ChannelSpec.Socket, schema_path: "./wherever.json"`

I don't think this works as intended just yet. I'll be using this branch to test against our actual usecase