### PR TITLE
Fix: Simplify Logic

### DIFF
--- a/lib/channel_spec/serializer.ex
+++ b/lib/channel_spec/serializer.ex
@@ -44,27 +44,21 @@ defmodule Serializer do
   # Helper function to ensure the order of the output json
   @spec to_ordered_structs(map()) :: Jason.OrderedObject.t()
   defp to_ordered_structs(map) when is_map(map) do
-    reverse_ordered =
-      map
-      |> Enum.to_list()
-      |> Enum.sort_by(fn {key, _val} -> key end, :asc)
-      |> Enum.reduce(%Jason.OrderedObject{}, fn
-        {key, value}, acc when is_map(value) ->
-          %{acc | values: [{key, to_ordered_structs(value)} | acc.values]}
+    map
+    |> Enum.to_list()
+    |> Enum.sort_by(fn {key, _val} -> key end, :desc)
+    |> Enum.reduce(%Jason.OrderedObject{}, fn
+      {key, value}, acc when is_map(value) ->
+        %{acc | values: [{key, to_ordered_structs(value)} | acc.values]}
 
-        {key, value}, acc when is_list(value) ->
-          %{acc | values: [{key, to_ordered_structs(value)} | acc.values]}
+      {key, value}, acc when is_list(value) ->
+        %{acc | values: [{key, to_ordered_structs(value)} | acc.values]}
 
-        {key, value}, acc ->
-          %{acc | values: [{key, value} | acc.values]}
-      end)
-
-    %{reverse_ordered | values: Enum.reverse(reverse_ordered.values)}
+      {key, value}, acc ->
+        %{acc | values: [{key, value} | acc.values]}
+    end)
   end
 
-  defp to_ordered_structs(list) when is_list(list) do
-    Enum.map(list, &to_ordered_structs/1)
-  end
-
-  defp to_ordered_structs(stuff), do: stuff
+  defp to_ordered_structs(list) when is_list(list), do: Enum.map(list, &to_ordered_structs/1)
+  defp to_ordered_structs(other), do: other
 end


### PR DESCRIPTION
Instead of sorting `asc` then reversing the result, just sort `desc` and trust the order