### PR TITLE
Improve assert_reply error messages

### DIFF
--- a/lib/channel_spec/testing.ex
+++ b/lib/channel_spec/testing.ex
@@ -113,7 +113,8 @@ defmodule ChannelSpec.Testing do
            ) do
     quote location: :keep do
       socket = Process.get(unquote(ref))
-      assert_reply(unquote(ref), unquote(status), reply = unquote(reply))
+      assert_reply(unquote(ref), status, reply)
+      assert {unquote(status), unquote(reply)} = {status, reply}
 
       normalized_reply = reply |> Jason.encode!() |> Jason.decode!()
 


### PR DESCRIPTION
Currently the error assertions happen directly on _all_ the messages that the channel has received, when we only very specifically care about the specific reply to our message.

This PR splits that assertion into two steps, the first step gets the reply, and the second step asserts on the expected status and reply. They are asserted together so that when there's an error you get detailed information about what the error payload is, otherwise your initial test failure may simply tell you something like ":ok does not equal :error"